### PR TITLE
Use ANSI clearing codes instead of \033c

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const streamer = stream => {
   let lastColor = -1;
   let newColor = 0;
   return setInterval(() => {
-    if (index >= frames.length) index = 0; stream.push('\033c');
+    if (index >= frames.length) index = 0; stream.push('\033[2J\033[H');
 
     newColor = Math.floor(Math.random() * numColors);
 


### PR DESCRIPTION
Mimic the behavior of using `\033c` by using `\033[2J\033H` to clear the screen instead.

- **`\033[2J`** clears the screen and (depending on implementation, I think?) returns the cursor to the home position.
- **`\033[H`** returns the cursor to the home position. (top left, I believe)

I haven't found reference to `\033c` in the documentation that I've perused, so I don't think that one was as standard or cool or whatever as this one, either.

The combination of these two resolves #1 on my end.  For me, no longer does the observed "phantom parrot" get rendered in the terminal.  This solution does have the downside of sending a few extra bytes down the wire, but I don't think that's critically bad in this case. :grin:

Resolves #1.