### PR TITLE
Clear the screen buffer if supported

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ const streamer = (stream, opts) => {
 
   return setInterval(() => {
     // clear the screen
-    stream.push('\033[2J\033[H');
+    stream.push('\033[2J\033[3J\033[H');
 
     const newColor = lastColor = selectColor(lastColor);
 


### PR DESCRIPTION
'curl parrot.live' uses a 'clear screen' ANSI sequence, which just pushes all visible lines to the scrollback buffer, which means that you can scroll up and see previous frames.
Most terminal emulators also support 'clear screen and scrollback buffer' not-really-ANSI sequence, '\033[3J'.
Since unsupported ANSI sequences are not (usually) rendered, i've just added that 'clear screen and buffer' after current 'clear screen' command, so that scroll bar that rapidly scales down does not scare people.